### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,3 +62,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,3 +78,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,23 @@
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,3 +70,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,3 +74,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,3 +66,7 @@ cache:
 cache:
   directories:
   - $HOME/.m2
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+fsdfsadfsd


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.