### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 sudo: false
 
 language: android
+
+git:
+  depth: 1


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.