### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,19 @@ sudo: false
 
 language: java
 
-install: travis_wait 30 mvn clean install -fn -e -B -V -nsu -P run-its -DskipITs -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+install: mvn clean install -fn -e -B -V -nsu -P run-its -DskipITs -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 script:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then travis_retry mvn --batch-mode --settings ~/settings.xml -Djava.awt.headless=true -Dgpg.defaultKeyring=false -Dgpg-keyname=1481F619 -Dgpg.publicKeyring="$TRAVIS_BUILD_DIR/src/travis/pubring.gpg" -Dgpg.secretKeyring="$TRAVIS_BUILD_DIR/src/travis/secretring.gpg" clean deploy -P deployment,create-modules,create-sources,create-javadoc,create-autoupdate,replace-windows-icon,create-exe,create-targz;fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then travis_retry mvn --batch-mode --settings ~/settings.xml -Djava.awt.headless=true -Dgpg.executable=gpg -Dgpg.defaultKeyring=false -Dgpg.useAgent=false -Dgpg-keyname=1481F619 -Dgpg.publicKeyring="$TRAVIS_BUILD_DIR/src/travis/pubring.gpg" -Dgpg.secretKeyring="$TRAVIS_BUILD_DIR/src/travis/secretring.gpg" clean deploy -P deployment,create-dmg;fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then mvn --batch-mode --settings ~/settings.xml -Djava.awt.headless=true -Dgpg.defaultKeyring=false -Dgpg-keyname=1481F619 -Dgpg.publicKeyring="$TRAVIS_BUILD_DIR/src/travis/pubring.gpg" -Dgpg.secretKeyring="$TRAVIS_BUILD_DIR/src/travis/secretring.gpg" clean deploy -P deployment,create-modules,create-sources,create-javadoc,create-autoupdate,replace-windows-icon,create-exe,create-targz;fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then mvn --batch-mode --settings ~/settings.xml -Djava.awt.headless=true -Dgpg.executable=gpg -Dgpg.defaultKeyring=false -Dgpg.useAgent=false -Dgpg-keyname=1481F619 -Dgpg.publicKeyring="$TRAVIS_BUILD_DIR/src/travis/pubring.gpg" -Dgpg.secretKeyring="$TRAVIS_BUILD_DIR/src/travis/secretring.gpg" clean deploy -P deployment,create-dmg;fi
 
 matrix:
+  fast_finish: true
   include:
     - name: "OpenJDK8"
   allow_failures:
     - env: ALLOW_FAILURE=true
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

If there are any inappropriate modifications, please give me feedback and I will change them.
