### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <!-- Encoding configuration -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    	<closeTestReports>true</closeTestReports>
     </properties>
 
     <build>
@@ -133,6 +134,13 @@
                         <configuration>
                             <argLine>@{argLine} -Xmx3000m -Dbcel.dontCache=true</argLine>
 		           <enableAssertions>true</enableAssertions>
+                        	<parallel>classes</parallel>
+                        	<useUnlimitedThreads>true</useUnlimitedThreads>
+                        	<forkCount>1.5C</forkCount>
+                        	<disableXmlReport>${closeTestReports}</disableXmlReport>
+
+
+
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION

According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
